### PR TITLE
chore: Disable Discord URL embeds to prevent clutter.

### DIFF
--- a/src/app/llm.py
+++ b/src/app/llm.py
@@ -104,7 +104,7 @@ def invoke_llm(prompt, userID):
     
     citation_text = "Sources:\n"
     for x in range(0, 3):
-        citation_text += citations[x].metadata['url'] + "\n"
+        citation_text += "<" + citations[x].metadata['url'] + ">\n"
 
     return response['response'] + "\n" + citation_text
 


### PR DESCRIPTION
**Prevent cluttering due to the embeds that discord generates for the list of URL citations.**


Before:
![image](https://github.com/user-attachments/assets/33d48273-5779-4c8b-b039-3dbd58fdf9e5)

After:
![image](https://github.com/user-attachments/assets/943d157f-04d6-4cff-9d46-e99ebf82d538)

